### PR TITLE
Fix #4: 翻訳サービスの抽象化層を実装

### DIFF
--- a/includes/Translation/AbstractTranslationService.php
+++ b/includes/Translation/AbstractTranslationService.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Abstract translation service class.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Translation;
+
+/**
+ * Base class for translation services.
+ */
+abstract class AbstractTranslationService implements TranslationServiceInterface {
+
+	/**
+	 * Service configuration.
+	 *
+	 * @var array
+	 */
+	protected $config = [];
+
+	/**
+	 * HTTP timeout in seconds.
+	 *
+	 * @var int
+	 */
+	protected $timeout = 10;
+
+	/**
+	 * Set configuration for the service.
+	 *
+	 * @param array $config Configuration array.
+	 */
+	public function set_config( array $config ): void {
+		$this->config = $config;
+	}
+
+	/**
+	 * Check if the service is available.
+	 *
+	 * @return bool
+	 */
+	public function is_available(): bool {
+		$required = $this->get_required_config();
+		
+		foreach ( $required as $key ) {
+			if ( empty( $this->config[ $key ] ) ) {
+				return false;
+			}
+		}
+		
+		return true;
+	}
+
+	/**
+	 * Make HTTP request to translation API.
+	 *
+	 * @param string $url     API endpoint URL.
+	 * @param array  $args    Request arguments.
+	 * @param string $method  HTTP method (GET or POST).
+	 *
+	 * @return array|WP_Error Response array or WP_Error on failure.
+	 */
+	protected function make_request( string $url, array $args = [], string $method = 'POST' ) {
+		$default_args = [
+			'timeout' => $this->timeout,
+			'headers' => [
+				'Content-Type' => 'application/json',
+			],
+		];
+
+		if ( 'POST' === $method ) {
+			$default_args['method'] = 'POST';
+			$default_args['body']   = wp_json_encode( $args );
+			$response               = wp_remote_post( $url, $default_args );
+		} else {
+			$url      = add_query_arg( $args, $url );
+			$response = wp_remote_get( $url, $default_args );
+		}
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		if ( null === $data ) {
+			return new \WP_Error( 'json_decode_error', __( 'Failed to decode JSON response', 'wp-smart-slug' ) );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Sanitize text for slug generation.
+	 *
+	 * @param string $text Text to sanitize.
+	 *
+	 * @return string Sanitized text suitable for slug.
+	 */
+	protected function sanitize_for_slug( string $text ): string {
+		// Remove HTML tags.
+		$text = strip_tags( $text );
+		
+		// Convert to lowercase.
+		$text = strtolower( $text );
+		
+		// Replace spaces with hyphens.
+		$text = str_replace( ' ', '-', $text );
+		
+		// Remove multiple hyphens.
+		$text = preg_replace( '/-+/', '-', $text );
+		
+		// Remove non-alphanumeric characters except hyphens.
+		$text = preg_replace( '/[^a-z0-9-]/', '', $text );
+		
+		// Trim hyphens from start and end.
+		$text = trim( $text, '-' );
+		
+		// Limit length to 50 characters for concise slugs.
+		if ( strlen( $text ) > 50 ) {
+			$text = substr( $text, 0, 50 );
+			// Trim at word boundary if possible.
+			$last_hyphen = strrpos( $text, '-' );
+			if ( $last_hyphen > 30 ) {
+				$text = substr( $text, 0, $last_hyphen );
+			}
+		}
+		
+		return $text;
+	}
+
+	/**
+	 * Log error for debugging.
+	 *
+	 * @param string $message Error message.
+	 * @param array  $context Additional context.
+	 */
+	protected function log_error( string $message, array $context = [] ): void {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log(
+				sprintf(
+					'[WP Smart Slug - %s] %s %s',
+					$this->get_name(),
+					$message,
+					$context ? wp_json_encode( $context ) : ''
+				)
+			);
+		}
+	}
+}

--- a/includes/Translation/SlugGenerator.php
+++ b/includes/Translation/SlugGenerator.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Slug generator class.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Translation;
+
+/**
+ * Generates URL-friendly slugs from translated text.
+ */
+class SlugGenerator {
+
+	/**
+	 * Translation service instance.
+	 *
+	 * @var TranslationServiceInterface|null
+	 */
+	private $translation_service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param TranslationServiceInterface|null $translation_service Translation service.
+	 */
+	public function __construct( ?TranslationServiceInterface $translation_service = null ) {
+		$this->translation_service = $translation_service;
+	}
+
+	/**
+	 * Set translation service.
+	 *
+	 * @param TranslationServiceInterface $service Translation service.
+	 */
+	public function set_translation_service( TranslationServiceInterface $service ): void {
+		$this->translation_service = $service;
+	}
+
+	/**
+	 * Generate slug from text.
+	 *
+	 * @param string $text   Text to convert to slug.
+	 * @param string $source Source language code.
+	 * @param string $target Target language code.
+	 *
+	 * @return string Generated slug.
+	 */
+	public function generate_slug( string $text, string $source = 'ja', string $target = 'en' ): string {
+		// If no translation service is available, return sanitized original text.
+		if ( ! $this->translation_service || ! $this->translation_service->is_available() ) {
+			return $this->fallback_slug( $text );
+		}
+
+		// Check if text needs translation (contains non-ASCII characters).
+		if ( ! $this->needs_translation( $text ) ) {
+			return sanitize_title( $text );
+		}
+
+		// Translate the text.
+		$result = $this->translation_service->translate( $text, $source, $target );
+
+		if ( ! $result->is_success() ) {
+			$this->log_translation_error( $text, $result );
+			return $this->fallback_slug( $text );
+		}
+
+		$translated = $result->get_text();
+
+		// Make the translation concise (1-2 words).
+		$translated = $this->make_concise( $translated );
+
+		// Sanitize for WordPress slug.
+		return sanitize_title( $translated );
+	}
+
+	/**
+	 * Generate slug for media filename.
+	 *
+	 * @param string $filename Original filename.
+	 *
+	 * @return string Translated filename.
+	 */
+	public function generate_media_slug( string $filename ): string {
+		// Get file extension.
+		$path_info = pathinfo( $filename );
+		$name      = $path_info['filename'] ?? '';
+		$extension = isset( $path_info['extension'] ) ? '.' . $path_info['extension'] : '';
+
+		// If filename is already ASCII, just sanitize it.
+		if ( ! $this->needs_translation( $name ) ) {
+			return sanitize_file_name( $filename );
+		}
+
+		// Generate slug for the filename part.
+		$slug = $this->generate_slug( $name );
+
+		// If translation failed, use fallback.
+		if ( empty( $slug ) || $slug === $this->fallback_slug( $name ) ) {
+			$slug = 'file-' . time();
+		}
+
+		return $slug . $extension;
+	}
+
+	/**
+	 * Check if text needs translation.
+	 *
+	 * @param string $text Text to check.
+	 *
+	 * @return bool True if translation is needed.
+	 */
+	private function needs_translation( string $text ): bool {
+		// Check if text contains non-ASCII characters.
+		return ! preg_match( '/^[\x20-\x7E]*$/', $text );
+	}
+
+	/**
+	 * Make translated text concise (1-2 words).
+	 *
+	 * @param string $text Translated text.
+	 *
+	 * @return string Concise text.
+	 */
+	private function make_concise( string $text ): string {
+		// Remove common articles and prepositions.
+		$stop_words = [ 'the', 'a', 'an', 'of', 'in', 'on', 'at', 'to', 'for', 'with', 'by' ];
+		
+		// Split into words.
+		$words = explode( ' ', strtolower( $text ) );
+		
+		// Filter out stop words.
+		$words = array_filter(
+			$words,
+			function ( $word ) use ( $stop_words ) {
+				return ! in_array( $word, $stop_words, true );
+			}
+		);
+		
+		// Take first 2 significant words.
+		$words = array_slice( $words, 0, 2 );
+		
+		return implode( ' ', $words );
+	}
+
+	/**
+	 * Generate fallback slug when translation fails.
+	 *
+	 * @param string $text Original text.
+	 *
+	 * @return string Fallback slug.
+	 */
+	private function fallback_slug( string $text ): string {
+		// Try to romanize if possible.
+		if ( function_exists( 'transliterator_transliterate' ) ) {
+			$romanized = transliterator_transliterate( 'Any-Latin; Latin-ASCII', $text );
+			if ( $romanized ) {
+				return sanitize_title( $romanized );
+			}
+		}
+
+		// Last resort: use timestamp-based slug.
+		return 'post-' . time();
+	}
+
+	/**
+	 * Log translation error.
+	 *
+	 * @param string             $text   Original text.
+	 * @param TranslationResult $result Translation result.
+	 */
+	private function log_translation_error( string $text, TranslationResult $result ): void {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log(
+				sprintf(
+					'[WP Smart Slug] Translation failed for "%s": %s',
+					$text,
+					$result->get_error() ?? 'Unknown error'
+				)
+			);
+		}
+	}
+}

--- a/includes/Translation/TranslationResult.php
+++ b/includes/Translation/TranslationResult.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Translation result class.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Translation;
+
+/**
+ * Represents a translation result.
+ */
+class TranslationResult {
+
+	/**
+	 * Translated text.
+	 *
+	 * @var string
+	 */
+	private $text;
+
+	/**
+	 * Source language.
+	 *
+	 * @var string
+	 */
+	private $source_language;
+
+	/**
+	 * Target language.
+	 *
+	 * @var string
+	 */
+	private $target_language;
+
+	/**
+	 * Whether translation was successful.
+	 *
+	 * @var bool
+	 */
+	private $success;
+
+	/**
+	 * Error message if translation failed.
+	 *
+	 * @var string|null
+	 */
+	private $error;
+
+	/**
+	 * Service that provided the translation.
+	 *
+	 * @var string
+	 */
+	private $service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $data Result data.
+	 */
+	public function __construct( array $data ) {
+		$this->text            = $data['text'] ?? '';
+		$this->source_language = $data['source_language'] ?? '';
+		$this->target_language = $data['target_language'] ?? '';
+		$this->success         = $data['success'] ?? false;
+		$this->error           = $data['error'] ?? null;
+		$this->service         = $data['service'] ?? '';
+	}
+
+	/**
+	 * Create a successful result.
+	 *
+	 * @param string $text            Translated text.
+	 * @param string $source_language Source language.
+	 * @param string $target_language Target language.
+	 * @param string $service         Service name.
+	 *
+	 * @return self
+	 */
+	public static function success( string $text, string $source_language, string $target_language, string $service ): self {
+		return new self(
+			[
+				'text'            => $text,
+				'source_language' => $source_language,
+				'target_language' => $target_language,
+				'success'         => true,
+				'service'         => $service,
+			]
+		);
+	}
+
+	/**
+	 * Create a failed result.
+	 *
+	 * @param string $error   Error message.
+	 * @param string $service Service name.
+	 *
+	 * @return self
+	 */
+	public static function error( string $error, string $service ): self {
+		return new self(
+			[
+				'success' => false,
+				'error'   => $error,
+				'service' => $service,
+			]
+		);
+	}
+
+	/**
+	 * Get translated text.
+	 *
+	 * @return string
+	 */
+	public function get_text(): string {
+		return $this->text;
+	}
+
+	/**
+	 * Get source language.
+	 *
+	 * @return string
+	 */
+	public function get_source_language(): string {
+		return $this->source_language;
+	}
+
+	/**
+	 * Get target language.
+	 *
+	 * @return string
+	 */
+	public function get_target_language(): string {
+		return $this->target_language;
+	}
+
+	/**
+	 * Check if translation was successful.
+	 *
+	 * @return bool
+	 */
+	public function is_success(): bool {
+		return $this->success;
+	}
+
+	/**
+	 * Get error message.
+	 *
+	 * @return string|null
+	 */
+	public function get_error(): ?string {
+		return $this->error;
+	}
+
+	/**
+	 * Get service name.
+	 *
+	 * @return string
+	 */
+	public function get_service(): string {
+		return $this->service;
+	}
+}

--- a/includes/Translation/TranslationServiceFactory.php
+++ b/includes/Translation/TranslationServiceFactory.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Translation service factory.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Translation;
+
+/**
+ * Factory class for creating translation service instances.
+ */
+class TranslationServiceFactory {
+
+	/**
+	 * Available translation services.
+	 *
+	 * @var array
+	 */
+	private static $services = [
+		'mymemory'     => 'WPSmartSlug\Translation\Services\MyMemoryService',
+		'libretranslate' => 'WPSmartSlug\Translation\Services\LibreTranslateService',
+		'deepl'        => 'WPSmartSlug\Translation\Services\DeepLService',
+	];
+
+	/**
+	 * Service instances cache.
+	 *
+	 * @var array
+	 */
+	private static $instances = [];
+
+	/**
+	 * Create a translation service instance.
+	 *
+	 * @param string $service_name Service name.
+	 * @param array  $config       Service configuration.
+	 *
+	 * @return TranslationServiceInterface|null Service instance or null if not found.
+	 */
+	public static function create( string $service_name, array $config = [] ): ?TranslationServiceInterface {
+		if ( ! isset( self::$services[ $service_name ] ) ) {
+			return null;
+		}
+
+		$cache_key = $service_name . ':' . md5( wp_json_encode( $config ) );
+
+		if ( ! isset( self::$instances[ $cache_key ] ) ) {
+			$class_name = self::$services[ $service_name ];
+			
+			if ( ! class_exists( $class_name ) ) {
+				return null;
+			}
+
+			$instance = new $class_name();
+			$instance->set_config( $config );
+			
+			self::$instances[ $cache_key ] = $instance;
+		}
+
+		return self::$instances[ $cache_key ];
+	}
+
+	/**
+	 * Get available service names.
+	 *
+	 * @return array Array of service names.
+	 */
+	public static function get_available_services(): array {
+		return array_keys( self::$services );
+	}
+
+	/**
+	 * Get service display names.
+	 *
+	 * @return array Array of service names with labels.
+	 */
+	public static function get_service_labels(): array {
+		return [
+			'mymemory'       => __( 'MyMemory Translation API', 'wp-smart-slug' ),
+			'libretranslate' => __( 'LibreTranslate', 'wp-smart-slug' ),
+			'deepl'          => __( 'DeepL API Free', 'wp-smart-slug' ),
+		];
+	}
+
+	/**
+	 * Register a custom translation service.
+	 *
+	 * @param string $name       Service name.
+	 * @param string $class_name Fully qualified class name.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public static function register_service( string $name, string $class_name ): bool {
+		if ( isset( self::$services[ $name ] ) ) {
+			return false;
+		}
+
+		if ( ! class_exists( $class_name ) ) {
+			return false;
+		}
+
+		$reflection = new \ReflectionClass( $class_name );
+		if ( ! $reflection->implementsInterface( TranslationServiceInterface::class ) ) {
+			return false;
+		}
+
+		self::$services[ $name ] = $class_name;
+		return true;
+	}
+
+	/**
+	 * Clear instances cache.
+	 */
+	public static function clear_cache(): void {
+		self::$instances = [];
+	}
+}

--- a/includes/Translation/TranslationServiceInterface.php
+++ b/includes/Translation/TranslationServiceInterface.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Translation service interface.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Translation;
+
+/**
+ * Interface for translation services.
+ */
+interface TranslationServiceInterface {
+
+	/**
+	 * Translate text from source language to target language.
+	 *
+	 * @param string $text   The text to translate.
+	 * @param string $source Source language code (e.g., 'ja' for Japanese).
+	 * @param string $target Target language code (e.g., 'en' for English).
+	 *
+	 * @return TranslationResult Translation result object.
+	 */
+	public function translate( string $text, string $source = 'ja', string $target = 'en' ): TranslationResult;
+
+	/**
+	 * Check if the service is available.
+	 *
+	 * @return bool True if service is available, false otherwise.
+	 */
+	public function is_available(): bool;
+
+	/**
+	 * Get the service name.
+	 *
+	 * @return string Service name.
+	 */
+	public function get_name(): string;
+
+	/**
+	 * Get required configuration keys.
+	 *
+	 * @return array Array of required configuration keys.
+	 */
+	public function get_required_config(): array;
+
+	/**
+	 * Set configuration for the service.
+	 *
+	 * @param array $config Configuration array.
+	 */
+	public function set_config( array $config ): void;
+}


### PR DESCRIPTION
## 概要
翻訳サービスの抽象化層を実装しました。これにより、MyMemory、LibreTranslate、DeepLの3つのサービスを統一的なインターフェースで扱えるようになります。

## 実装内容
- `TranslationServiceInterface`: 統一されたAPIを定義
- `TranslationResult`: 翻訳結果の標準化されたデータ構造
- `AbstractTranslationService`: 共通機能を実装した基底クラス
- `TranslationServiceFactory`: サービスのインスタンス化を管理
- `SlugGenerator`: 翻訳されたテキストをURL用のスラッグに変換

## 特徴
- エラーハンドリングとロギング機能
- 簡潔なスラッグ生成（1-2単語）
- 翻訳失敗時のフォールバック機構
- サービスの動的登録サポート

Closes #4