### PR TITLE
Fix #6: 各翻訳サービスの実装

### DIFF
--- a/includes/Translation/Services/DeepLService.php
+++ b/includes/Translation/Services/DeepLService.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * DeepL API Free service.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Translation\Services;
+
+use WPSmartSlug\Translation\AbstractTranslationService;
+use WPSmartSlug\Translation\TranslationResult;
+
+/**
+ * DeepL translation service implementation.
+ */
+class DeepLService extends AbstractTranslationService {
+
+	/**
+	 * API endpoint URL for free tier.
+	 *
+	 * @var string
+	 */
+	private const API_URL_FREE = 'https://api-free.deepl.com/v2/translate';
+
+	/**
+	 * Monthly character limit for free tier.
+	 *
+	 * @var int
+	 */
+	private const FREE_TIER_LIMIT = 500000;
+
+	/**
+	 * Get the service name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'DeepL';
+	}
+
+	/**
+	 * Get required configuration keys.
+	 *
+	 * @return array
+	 */
+	public function get_required_config(): array {
+		return [ 'api_key' ];
+	}
+
+	/**
+	 * Translate text.
+	 *
+	 * @param string $text   The text to translate.
+	 * @param string $source Source language code.
+	 * @param string $target Target language code.
+	 *
+	 * @return TranslationResult
+	 */
+	public function translate( string $text, string $source = 'ja', string $target = 'en' ): TranslationResult {
+		if ( empty( $text ) ) {
+			return TranslationResult::error( __( 'Empty text provided', 'wp-smart-slug' ), $this->get_name() );
+		}
+
+		if ( empty( $this->config['api_key'] ) ) {
+			return TranslationResult::error( __( 'DeepL API key is required', 'wp-smart-slug' ), $this->get_name() );
+		}
+
+		// Convert language codes to DeepL format.
+		$source = $this->convert_language_code( $source, true );
+		$target = $this->convert_language_code( $target, false );
+
+		// Build request body.
+		$body = [
+			'auth_key'        => $this->config['api_key'],
+			'text'            => $text,
+			'source_lang'     => strtoupper( $source ),
+			'target_lang'     => strtoupper( $target ),
+			'preserve_formatting' => '0',
+		];
+
+		// Custom headers for DeepL.
+		$args = [
+			'timeout' => $this->timeout,
+			'headers' => [
+				'Content-Type' => 'application/x-www-form-urlencoded',
+			],
+			'body' => $body,
+			'method' => 'POST',
+		];
+
+		// Make API request.
+		$response = wp_remote_post( self::API_URL_FREE, $args );
+
+		if ( is_wp_error( $response ) ) {
+			$this->log_error( 'API request failed', [ 'error' => $response->get_error_message() ] );
+			return TranslationResult::error(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Translation request failed: %s', 'wp-smart-slug' ),
+					$response->get_error_message()
+				),
+				$this->get_name()
+			);
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		$response_body = wp_remote_retrieve_body( $response );
+		$data          = json_decode( $response_body, true );
+
+		// Handle HTTP errors.
+		if ( 200 !== $response_code ) {
+			$error_msg = __( 'Unknown error', 'wp-smart-slug' );
+
+			if ( 403 === $response_code ) {
+				$error_msg = __( 'Invalid DeepL API key', 'wp-smart-slug' );
+			} elseif ( 456 === $response_code ) {
+				$error_msg = __( 'DeepL API quota exceeded. Monthly limit reached.', 'wp-smart-slug' );
+			} elseif ( isset( $data['message'] ) ) {
+				$error_msg = $data['message'];
+			}
+
+			$this->log_error( 'API returned error', [ 'code' => $response_code, 'body' => $response_body ] );
+			
+			return TranslationResult::error(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'DeepL API error: %s', 'wp-smart-slug' ),
+					$error_msg
+				),
+				$this->get_name()
+			);
+		}
+
+		// Parse response.
+		if ( ! isset( $data['translations'] ) || ! is_array( $data['translations'] ) || empty( $data['translations'] ) ) {
+			return TranslationResult::error(
+				__( 'No translation returned', 'wp-smart-slug' ),
+				$this->get_name()
+			);
+		}
+
+		// Extract translated text.
+		$translated_text = $data['translations'][0]['text'] ?? '';
+
+		if ( empty( $translated_text ) ) {
+			return TranslationResult::error(
+				__( 'Empty translation returned', 'wp-smart-slug' ),
+				$this->get_name()
+			);
+		}
+
+		// Sanitize for slug.
+		$translated_text = $this->sanitize_for_slug( $translated_text );
+
+		return TranslationResult::success(
+			$translated_text,
+			$source,
+			$target,
+			$this->get_name()
+		);
+	}
+
+	/**
+	 * Convert language codes to DeepL format.
+	 *
+	 * @param string $code   Language code.
+	 * @param bool   $source True for source language, false for target.
+	 *
+	 * @return string Converted language code.
+	 */
+	private function convert_language_code( string $code, bool $source ): string {
+		// DeepL uses uppercase codes and some specific mappings.
+		$mappings = [
+			'ja' => 'JA',
+			'en' => 'EN-US', // Use American English as default.
+			'zh' => 'ZH',
+			'ko' => 'KO',
+			'es' => 'ES',
+			'fr' => 'FR',
+			'de' => 'DE',
+			'it' => 'IT',
+			'pt' => 'PT-PT',
+			'ru' => 'RU',
+		];
+
+		// For source language, use generic EN instead of EN-US.
+		if ( $source && 'en' === strtolower( $code ) ) {
+			return 'EN';
+		}
+
+		return $mappings[ strtolower( $code ) ] ?? strtoupper( $code );
+	}
+}

--- a/includes/Translation/Services/LibreTranslateService.php
+++ b/includes/Translation/Services/LibreTranslateService.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * LibreTranslate service.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Translation\Services;
+
+use WPSmartSlug\Translation\AbstractTranslationService;
+use WPSmartSlug\Translation\TranslationResult;
+
+/**
+ * LibreTranslate service implementation.
+ */
+class LibreTranslateService extends AbstractTranslationService {
+
+	/**
+	 * Default API URL (official instance).
+	 *
+	 * @var string
+	 */
+	private const DEFAULT_API_URL = 'https://libretranslate.com';
+
+	/**
+	 * API endpoint path.
+	 *
+	 * @var string
+	 */
+	private const TRANSLATE_ENDPOINT = '/translate';
+
+	/**
+	 * Get the service name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'LibreTranslate';
+	}
+
+	/**
+	 * Get required configuration keys.
+	 *
+	 * @return array
+	 */
+	public function get_required_config(): array {
+		// API host is required, API key is optional.
+		return [ 'api_host' ];
+	}
+
+	/**
+	 * Translate text.
+	 *
+	 * @param string $text   The text to translate.
+	 * @param string $source Source language code.
+	 * @param string $target Target language code.
+	 *
+	 * @return TranslationResult
+	 */
+	public function translate( string $text, string $source = 'ja', string $target = 'en' ): TranslationResult {
+		if ( empty( $text ) ) {
+			return TranslationResult::error( __( 'Empty text provided', 'wp-smart-slug' ), $this->get_name() );
+		}
+
+		// Get API host.
+		$api_host = $this->config['api_host'] ?? self::DEFAULT_API_URL;
+		$api_host = trailingslashit( $api_host );
+		$url      = $api_host . ltrim( self::TRANSLATE_ENDPOINT, '/' );
+
+		// Build request body.
+		$body = [
+			'q'      => $text,
+			'source' => $source,
+			'target' => $target,
+			'format' => 'text',
+		];
+
+		// Add API key if provided.
+		if ( ! empty( $this->config['api_key'] ) ) {
+			$body['api_key'] = $this->config['api_key'];
+		}
+
+		// Make API request.
+		$response = $this->make_request( $url, $body );
+
+		if ( is_wp_error( $response ) ) {
+			$this->log_error( 'API request failed', [ 'error' => $response->get_error_message() ] );
+			return TranslationResult::error(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Translation request failed: %s', 'wp-smart-slug' ),
+					$response->get_error_message()
+				),
+				$this->get_name()
+			);
+		}
+
+		// Check for API errors.
+		if ( isset( $response['error'] ) ) {
+			$error_msg = $response['error'];
+			$this->log_error( 'API returned error', [ 'error' => $error_msg ] );
+
+			// Handle specific error messages.
+			if ( stripos( $error_msg, 'api key' ) !== false ) {
+				$error_msg = __( 'API key is required for this LibreTranslate instance', 'wp-smart-slug' );
+			} elseif ( stripos( $error_msg, 'rate limit' ) !== false ) {
+				$error_msg = __( 'Rate limit exceeded. Please try again later or provide an API key.', 'wp-smart-slug' );
+			}
+
+			return TranslationResult::error(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'LibreTranslate API error: %s', 'wp-smart-slug' ),
+					$error_msg
+				),
+				$this->get_name()
+			);
+		}
+
+		// Extract translated text.
+		$translated_text = $response['translatedText'] ?? '';
+
+		if ( empty( $translated_text ) ) {
+			return TranslationResult::error(
+				__( 'No translation returned', 'wp-smart-slug' ),
+				$this->get_name()
+			);
+		}
+
+		// Sanitize for slug.
+		$translated_text = $this->sanitize_for_slug( $translated_text );
+
+		return TranslationResult::success(
+			$translated_text,
+			$source,
+			$target,
+			$this->get_name()
+		);
+	}
+
+	/**
+	 * Check if the service is available.
+	 *
+	 * @return bool
+	 */
+	public function is_available(): bool {
+		// Check if API host is configured.
+		return ! empty( $this->config['api_host'] );
+	}
+}

--- a/includes/Translation/Services/MyMemoryService.php
+++ b/includes/Translation/Services/MyMemoryService.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * MyMemory Translation API service.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Translation\Services;
+
+use WPSmartSlug\Translation\AbstractTranslationService;
+use WPSmartSlug\Translation\TranslationResult;
+
+/**
+ * MyMemory translation service implementation.
+ */
+class MyMemoryService extends AbstractTranslationService {
+
+	/**
+	 * API endpoint URL.
+	 *
+	 * @var string
+	 */
+	private const API_URL = 'https://api.mymemory.translated.net/get';
+
+	/**
+	 * Rate limit - requests per day for anonymous usage.
+	 *
+	 * @var int
+	 */
+	private const RATE_LIMIT_ANONYMOUS = 5000;
+
+	/**
+	 * Get the service name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'MyMemory';
+	}
+
+	/**
+	 * Get required configuration keys.
+	 *
+	 * @return array
+	 */
+	public function get_required_config(): array {
+		// MyMemory doesn't require API key for basic usage.
+		return [];
+	}
+
+	/**
+	 * Translate text.
+	 *
+	 * @param string $text   The text to translate.
+	 * @param string $source Source language code.
+	 * @param string $target Target language code.
+	 *
+	 * @return TranslationResult
+	 */
+	public function translate( string $text, string $source = 'ja', string $target = 'en' ): TranslationResult {
+		if ( empty( $text ) ) {
+			return TranslationResult::error( __( 'Empty text provided', 'wp-smart-slug' ), $this->get_name() );
+		}
+
+		// Build request parameters.
+		$params = [
+			'q'        => $text,
+			'langpair' => $source . '|' . $target,
+		];
+
+		// Add API key if provided (for higher limits).
+		if ( ! empty( $this->config['api_key'] ) ) {
+			$params['key'] = $this->config['api_key'];
+		}
+
+		// Add email if provided (recommended by MyMemory).
+		if ( ! empty( $this->config['email'] ) ) {
+			$params['de'] = $this->config['email'];
+		}
+
+		// Make API request.
+		$response = $this->make_request( self::API_URL, $params, 'GET' );
+
+		if ( is_wp_error( $response ) ) {
+			$this->log_error( 'API request failed', [ 'error' => $response->get_error_message() ] );
+			return TranslationResult::error(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Translation request failed: %s', 'wp-smart-slug' ),
+					$response->get_error_message()
+				),
+				$this->get_name()
+			);
+		}
+
+		// Parse response.
+		if ( ! isset( $response['responseStatus'] ) || 200 !== (int) $response['responseStatus'] ) {
+			$error_msg = $response['responseDetails'] ?? __( 'Unknown error', 'wp-smart-slug' );
+			$this->log_error( 'API returned error', [ 'response' => $response ] );
+			return TranslationResult::error(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'MyMemory API error: %s', 'wp-smart-slug' ),
+					$error_msg
+				),
+				$this->get_name()
+			);
+		}
+
+		// Check for quota exceeded.
+		if ( isset( $response['quotaFinished'] ) && $response['quotaFinished'] ) {
+			return TranslationResult::error(
+				__( 'MyMemory API quota exceeded. Please try again later or provide an API key.', 'wp-smart-slug' ),
+				$this->get_name()
+			);
+		}
+
+		// Extract translated text.
+		$translated_text = $response['responseData']['translatedText'] ?? '';
+
+		if ( empty( $translated_text ) ) {
+			return TranslationResult::error(
+				__( 'No translation returned', 'wp-smart-slug' ),
+				$this->get_name()
+			);
+		}
+
+		// Sanitize for slug.
+		$translated_text = $this->sanitize_for_slug( $translated_text );
+
+		return TranslationResult::success(
+			$translated_text,
+			$source,
+			$target,
+			$this->get_name()
+		);
+	}
+
+	/**
+	 * Check if the service is available.
+	 *
+	 * @return bool
+	 */
+	public function is_available(): bool {
+		// MyMemory is always available (doesn't require API key).
+		return true;
+	}
+}


### PR DESCRIPTION
## 概要
3つの翻訳サービスの具体的な実装を完了しました。

## 実装したサービス

### MyMemoryService
- 無料で利用可能（APIキー不要）
- 1日5000リクエストまで匿名利用可能
- APIキー設定で制限緩和可能
- クォータ超過時の適切なエラーハンドリング

### LibreTranslateService
- カスタムホストの設定に対応
- APIキーはオプション（インスタンスによって必要）
- 自己ホスト型や公開インスタンスの両方に対応
- 詳細なエラーメッセージとハンドリング

### DeepLService
- DeepL API Free tier対応
- APIキー認証が必要
- 月50万文字までの無料利用
- DeepL固有の言語コード変換
- 適切なHTTPフォームエンコーディング

## 共通機能
- WordPress HTTP APIを使用
- エラーハンドリングとロギング
- レート制限の検出
- slug用のテキスト sanitization
- 統一されたインターフェース

Closes #6