### PR TITLE
Fix #5: 管理画面の実装

### DIFF
--- a/admin/AdminManager.php
+++ b/admin/AdminManager.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Admin manager class.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Admin;
+
+use WPSmartSlug\Translation\TranslationServiceFactory;
+
+/**
+ * Manages admin interface functionality.
+ */
+class AdminManager {
+
+	/**
+	 * Settings page slug.
+	 *
+	 * @var string
+	 */
+	private const SETTINGS_PAGE = 'wp-smart-slug';
+
+	/**
+	 * Settings group name.
+	 *
+	 * @var string
+	 */
+	private const SETTINGS_GROUP = 'wp_smart_slug_settings';
+
+	/**
+	 * Instance of this class.
+	 *
+	 * @var AdminManager|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return AdminManager
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Initialize admin functionality.
+	 */
+	private function init() {
+		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
+		add_filter( 'plugin_action_links_' . WP_SMART_SLUG_PLUGIN_BASENAME, [ $this, 'add_settings_link' ] );
+	}
+
+	/**
+	 * Add admin menu.
+	 */
+	public function add_admin_menu() {
+		add_options_page(
+			__( 'WP Smart Slug Settings', 'wp-smart-slug' ),
+			__( 'WP Smart Slug', 'wp-smart-slug' ),
+			'manage_options',
+			self::SETTINGS_PAGE,
+			[ $this, 'render_settings_page' ]
+		);
+	}
+
+	/**
+	 * Register settings.
+	 */
+	public function register_settings() {
+		register_setting(
+			self::SETTINGS_GROUP,
+			'wp_smart_slug_translation_service',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => [ $this, 'sanitize_translation_service' ],
+				'default'           => 'mymemory',
+			]
+		);
+
+		register_setting(
+			self::SETTINGS_GROUP,
+			'wp_smart_slug_api_key',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+				'default'           => '',
+			]
+		);
+
+		register_setting(
+			self::SETTINGS_GROUP,
+			'wp_smart_slug_api_host',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => 'esc_url_raw',
+				'default'           => '',
+			]
+		);
+
+		register_setting(
+			self::SETTINGS_GROUP,
+			'wp_smart_slug_enable_posts',
+			[
+				'type'    => 'boolean',
+				'default' => true,
+			]
+		);
+
+		register_setting(
+			self::SETTINGS_GROUP,
+			'wp_smart_slug_enable_pages',
+			[
+				'type'    => 'boolean',
+				'default' => true,
+			]
+		);
+
+		register_setting(
+			self::SETTINGS_GROUP,
+			'wp_smart_slug_enable_media',
+			[
+				'type'    => 'boolean',
+				'default' => true,
+			]
+		);
+
+		// Add settings sections.
+		add_settings_section(
+			'wp_smart_slug_translation_section',
+			__( 'Translation Service Settings', 'wp-smart-slug' ),
+			[ $this, 'render_translation_section' ],
+			self::SETTINGS_PAGE
+		);
+
+		add_settings_section(
+			'wp_smart_slug_features_section',
+			__( 'Feature Settings', 'wp-smart-slug' ),
+			[ $this, 'render_features_section' ],
+			self::SETTINGS_PAGE
+		);
+
+		// Add settings fields.
+		add_settings_field(
+			'translation_service',
+			__( 'Translation Service', 'wp-smart-slug' ),
+			[ $this, 'render_translation_service_field' ],
+			self::SETTINGS_PAGE,
+			'wp_smart_slug_translation_section'
+		);
+
+		add_settings_field(
+			'api_key',
+			__( 'API Key', 'wp-smart-slug' ),
+			[ $this, 'render_api_key_field' ],
+			self::SETTINGS_PAGE,
+			'wp_smart_slug_translation_section'
+		);
+
+		add_settings_field(
+			'api_host',
+			__( 'API Host', 'wp-smart-slug' ),
+			[ $this, 'render_api_host_field' ],
+			self::SETTINGS_PAGE,
+			'wp_smart_slug_translation_section'
+		);
+
+		add_settings_field(
+			'enable_posts',
+			__( 'Enable for Posts', 'wp-smart-slug' ),
+			[ $this, 'render_enable_posts_field' ],
+			self::SETTINGS_PAGE,
+			'wp_smart_slug_features_section'
+		);
+
+		add_settings_field(
+			'enable_pages',
+			__( 'Enable for Pages', 'wp-smart-slug' ),
+			[ $this, 'render_enable_pages_field' ],
+			self::SETTINGS_PAGE,
+			'wp_smart_slug_features_section'
+		);
+
+		add_settings_field(
+			'enable_media',
+			__( 'Enable for Media', 'wp-smart-slug' ),
+			[ $this, 'render_enable_media_field' ],
+			self::SETTINGS_PAGE,
+			'wp_smart_slug_features_section'
+		);
+	}
+
+	/**
+	 * Sanitize translation service selection.
+	 *
+	 * @param string $value The value to sanitize.
+	 *
+	 * @return string Sanitized value.
+	 */
+	public function sanitize_translation_service( $value ) {
+		$available_services = TranslationServiceFactory::get_available_services();
+		return in_array( $value, $available_services, true ) ? $value : 'mymemory';
+	}
+
+	/**
+	 * Enqueue admin scripts and styles.
+	 *
+	 * @param string $hook_suffix The current admin page.
+	 */
+	public function enqueue_admin_scripts( $hook_suffix ) {
+		if ( 'settings_page_' . self::SETTINGS_PAGE !== $hook_suffix ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'wp-smart-slug-admin',
+			WP_SMART_SLUG_PLUGIN_URL . 'assets/js/admin.js',
+			[ 'jquery' ],
+			WP_SMART_SLUG_VERSION,
+			true
+		);
+
+		wp_enqueue_style(
+			'wp-smart-slug-admin',
+			WP_SMART_SLUG_PLUGIN_URL . 'assets/css/admin.css',
+			[],
+			WP_SMART_SLUG_VERSION
+		);
+	}
+
+	/**
+	 * Add settings link to plugin actions.
+	 *
+	 * @param array $links Plugin action links.
+	 *
+	 * @return array Modified action links.
+	 */
+	public function add_settings_link( $links ) {
+		$settings_link = sprintf(
+			'<a href="%s">%s</a>',
+			admin_url( 'options-general.php?page=' . self::SETTINGS_PAGE ),
+			__( 'Settings', 'wp-smart-slug' )
+		);
+
+		array_unshift( $links, $settings_link );
+		return $links;
+	}
+
+	/**
+	 * Render settings page.
+	 */
+	public function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-smart-slug' ) );
+		}
+
+		include WP_SMART_SLUG_PLUGIN_DIR . 'admin/views/settings-page.php';
+	}
+
+	/**
+	 * Render translation section description.
+	 */
+	public function render_translation_section() {
+		echo '<p>' . esc_html__( 'Configure your preferred translation service and API credentials.', 'wp-smart-slug' ) . '</p>';
+	}
+
+	/**
+	 * Render features section description.
+	 */
+	public function render_features_section() {
+		echo '<p>' . esc_html__( 'Choose which content types should have their slugs automatically translated.', 'wp-smart-slug' ) . '</p>';
+	}
+
+	/**
+	 * Render translation service field.
+	 */
+	public function render_translation_service_field() {
+		$current_service = get_option( 'wp_smart_slug_translation_service', 'mymemory' );
+		$service_labels  = TranslationServiceFactory::get_service_labels();
+
+		echo '<select id="translation_service" name="wp_smart_slug_translation_service">';
+		foreach ( $service_labels as $value => $label ) {
+			printf(
+				'<option value="%s"%s>%s</option>',
+				esc_attr( $value ),
+				selected( $current_service, $value, false ),
+				esc_html( $label )
+			);
+		}
+		echo '</select>';
+		echo '<p class="description">' . esc_html__( 'Select the translation service to use for generating English slugs.', 'wp-smart-slug' ) . '</p>';
+	}
+
+	/**
+	 * Render API key field.
+	 */
+	public function render_api_key_field() {
+		$api_key = get_option( 'wp_smart_slug_api_key', '' );
+		printf(
+			'<input type="password" id="api_key" name="wp_smart_slug_api_key" value="%s" class="regular-text" />',
+			esc_attr( $api_key )
+		);
+		echo '<p class="description" id="api_key_description">' . esc_html__( 'Enter your API key if required by the selected service.', 'wp-smart-slug' ) . '</p>';
+	}
+
+	/**
+	 * Render API host field.
+	 */
+	public function render_api_host_field() {
+		$api_host = get_option( 'wp_smart_slug_api_host', '' );
+		printf(
+			'<input type="url" id="api_host" name="wp_smart_slug_api_host" value="%s" class="regular-text" placeholder="https://libretranslate.com" />',
+			esc_attr( $api_host )
+		);
+		echo '<p class="description" id="api_host_description">' . esc_html__( 'Enter the API host URL for LibreTranslate instances.', 'wp-smart-slug' ) . '</p>';
+	}
+
+	/**
+	 * Render enable posts field.
+	 */
+	public function render_enable_posts_field() {
+		$enabled = get_option( 'wp_smart_slug_enable_posts', true );
+		printf(
+			'<input type="checkbox" id="enable_posts" name="wp_smart_slug_enable_posts" value="1"%s />',
+			checked( $enabled, true, false )
+		);
+		echo '<label for="enable_posts">' . esc_html__( 'Automatically translate post slugs', 'wp-smart-slug' ) . '</label>';
+	}
+
+	/**
+	 * Render enable pages field.
+	 */
+	public function render_enable_pages_field() {
+		$enabled = get_option( 'wp_smart_slug_enable_pages', true );
+		printf(
+			'<input type="checkbox" id="enable_pages" name="wp_smart_slug_enable_pages" value="1"%s />',
+			checked( $enabled, true, false )
+		);
+		echo '<label for="enable_pages">' . esc_html__( 'Automatically translate page slugs', 'wp-smart-slug' ) . '</label>';
+	}
+
+	/**
+	 * Render enable media field.
+	 */
+	public function render_enable_media_field() {
+		$enabled = get_option( 'wp_smart_slug_enable_media', true );
+		printf(
+			'<input type="checkbox" id="enable_media" name="wp_smart_slug_enable_media" value="1"%s />',
+			checked( $enabled, true, false )
+		);
+		echo '<label for="enable_media">' . esc_html__( 'Automatically translate media filenames', 'wp-smart-slug' ) . '</label>';
+	}
+}

--- a/admin/views/settings-page.php
+++ b/admin/views/settings-page.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Settings page template.
+ *
+ * @package WPSmartSlug
+ */
+
+// Prevent direct access.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+
+<div class="wrap">
+	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+
+	<?php settings_errors(); ?>
+
+	<form method="post" action="options.php">
+		<?php
+		settings_fields( 'wp_smart_slug_settings' );
+		do_settings_sections( 'wp-smart-slug' );
+		submit_button();
+		?>
+	</form>
+
+	<div class="wp-smart-slug-info">
+		<h2><?php esc_html_e( 'About WP Smart Slug', 'wp-smart-slug' ); ?></h2>
+		<p><?php esc_html_e( 'WP Smart Slug automatically translates Japanese URLs (slugs) to English to prevent long base64-encoded URLs in WordPress.', 'wp-smart-slug' ); ?></p>
+		
+		<h3><?php esc_html_e( 'Translation Services', 'wp-smart-slug' ); ?></h3>
+		<ul>
+			<li>
+				<strong><?php esc_html_e( 'MyMemory Translation API', 'wp-smart-slug' ); ?></strong>: 
+				<?php esc_html_e( 'Free service with up to 5,000 requests per day. No API key required for basic usage.', 'wp-smart-slug' ); ?>
+			</li>
+			<li>
+				<strong><?php esc_html_e( 'LibreTranslate', 'wp-smart-slug' ); ?></strong>: 
+				<?php esc_html_e( 'Open-source translation service. Requires host URL, API key may be optional depending on the instance.', 'wp-smart-slug' ); ?>
+			</li>
+			<li>
+				<strong><?php esc_html_e( 'DeepL API Free', 'wp-smart-slug' ); ?></strong>: 
+				<?php esc_html_e( 'High-quality translation service with 500,000 characters per month free. Requires API key.', 'wp-smart-slug' ); ?>
+			</li>
+		</ul>
+
+		<h3><?php esc_html_e( 'How it works', 'wp-smart-slug' ); ?></h3>
+		<ol>
+			<li><?php esc_html_e( 'When you create a post, page, or upload media with Japanese text', 'wp-smart-slug' ); ?></li>
+			<li><?php esc_html_e( 'The plugin automatically translates the title/filename to English', 'wp-smart-slug' ); ?></li>
+			<li><?php esc_html_e( 'A concise, URL-friendly slug is generated (1-2 words)', 'wp-smart-slug' ); ?></li>
+			<li><?php esc_html_e( 'Your URLs remain clean and SEO-friendly', 'wp-smart-slug' ); ?></li>
+		</ol>
+
+		<p>
+			<strong><?php esc_html_e( 'Note:', 'wp-smart-slug' ); ?></strong>
+			<?php esc_html_e( 'If translation fails, the plugin will fall back to a generic slug to ensure your content is still accessible.', 'wp-smart-slug' ); ?>
+		</p>
+	</div>
+</div>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,80 @@
+/**
+ * Admin styles for WP Smart Slug.
+ */
+
+.wp-smart-slug-info {
+	margin-top: 2em;
+	padding: 1em;
+	background: #f9f9f9;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+}
+
+.wp-smart-slug-info h2 {
+	margin-top: 0;
+	color: #333;
+}
+
+.wp-smart-slug-info h3 {
+	margin-top: 1.5em;
+	margin-bottom: 0.5em;
+	color: #666;
+}
+
+.wp-smart-slug-info ul,
+.wp-smart-slug-info ol {
+	margin-left: 1.5em;
+}
+
+.wp-smart-slug-info li {
+	margin-bottom: 0.5em;
+}
+
+/* Service-specific field visibility */
+.service-field {
+	display: none;
+}
+
+.service-field.active {
+	display: table-row;
+}
+
+/* API key field styling */
+#api_key {
+	font-family: 'Courier New', Courier, monospace;
+}
+
+/* Description styling */
+.form-table .description {
+	margin-top: 5px;
+	font-style: italic;
+	color: #666;
+}
+
+/* Status indicators */
+.status-indicator {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 3px;
+	font-size: 11px;
+	font-weight: bold;
+	text-transform: uppercase;
+}
+
+.status-indicator.available {
+	background-color: #d4edda;
+	color: #155724;
+	border: 1px solid #c3e6cb;
+}
+
+.status-indicator.unavailable {
+	background-color: #f8d7da;
+	color: #721c24;
+	border: 1px solid #f5c6cb;
+}
+
+.status-indicator.unknown {
+	background-color: #fff3cd;
+	color: #856404;
+	border: 1px solid #ffeaa7;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,141 @@
+/**
+ * Admin JavaScript for WP Smart Slug.
+ */
+
+(function($) {
+	'use strict';
+
+	$(document).ready(function() {
+		// Service-specific field visibility
+		const serviceSelect = $('#translation_service');
+		const apiKeyRow = $('#api_key').closest('tr');
+		const apiHostRow = $('#api_host').closest('tr');
+		const apiKeyDescription = $('#api_key_description');
+		const apiHostDescription = $('#api_host_description');
+
+		// Service descriptions
+		const serviceDescriptions = {
+			mymemory: {
+				apiKey: 'Optional. Provides higher rate limits when provided.',
+				apiHost: 'Not used for MyMemory service.',
+				showApiKey: true,
+				showApiHost: false
+			},
+			libretranslate: {
+				apiKey: 'Optional. Some LibreTranslate instances require an API key.',
+				apiHost: 'Required. Enter the URL of your LibreTranslate instance.',
+				showApiKey: true,
+				showApiHost: true
+			},
+			deepl: {
+				apiKey: 'Required. Get your free API key from DeepL.',
+				apiHost: 'Not used for DeepL service.',
+				showApiKey: true,
+				showApiHost: false
+			}
+		};
+
+		// Update field visibility and descriptions
+		function updateServiceFields() {
+			const selectedService = serviceSelect.val();
+			const config = serviceDescriptions[selectedService] || serviceDescriptions.mymemory;
+
+			// Show/hide API key field
+			if (config.showApiKey) {
+				apiKeyRow.show();
+				apiKeyDescription.text(config.apiKey);
+			} else {
+				apiKeyRow.hide();
+			}
+
+			// Show/hide API host field
+			if (config.showApiHost) {
+				apiHostRow.show();
+				apiHostDescription.text(config.apiHost);
+			} else {
+				apiHostRow.hide();
+			}
+
+			// Add required indicators
+			const apiKeyLabel = $('label[for="api_key"]');
+			const apiHostLabel = $('label[for="api_host"]');
+
+			// Remove existing required indicators
+			apiKeyLabel.find('.required').remove();
+			apiHostLabel.find('.required').remove();
+
+			// Add required indicators where needed
+			if (selectedService === 'deepl' && config.showApiKey) {
+				apiKeyLabel.append(' <span class="required" style="color: red;">*</span>');
+			}
+			if (selectedService === 'libretranslate' && config.showApiHost) {
+				apiHostLabel.append(' <span class="required" style="color: red;">*</span>');
+			}
+		}
+
+		// Initialize field visibility
+		updateServiceFields();
+
+		// Update when service changes
+		serviceSelect.on('change', updateServiceFields);
+
+		// Test connection functionality (placeholder for future implementation)
+		function addTestConnectionButton() {
+			const testButton = $('<button type="button" class="button button-secondary">Test Connection</button>');
+			testButton.insertAfter($('#api_key'));
+			
+			testButton.on('click', function() {
+				// Placeholder for test connection functionality
+				alert('Test connection functionality will be implemented in a future version.');
+			});
+		}
+
+		// Uncomment to add test connection button
+		// addTestConnectionButton();
+
+		// Form validation
+		$('form').on('submit', function(e) {
+			const selectedService = serviceSelect.val();
+			const apiKey = $('#api_key').val();
+			const apiHost = $('#api_host').val();
+
+			let hasError = false;
+			let errorMessage = '';
+
+			// Validate DeepL requires API key
+			if (selectedService === 'deepl' && !apiKey.trim()) {
+				hasError = true;
+				errorMessage = 'DeepL service requires an API key.';
+			}
+
+			// Validate LibreTranslate requires host
+			if (selectedService === 'libretranslate' && !apiHost.trim()) {
+				hasError = true;
+				errorMessage = 'LibreTranslate service requires an API host URL.';
+			}
+
+			if (hasError) {
+				e.preventDefault();
+				alert(errorMessage);
+				return false;
+			}
+		});
+
+		// Show/hide password for API key field
+		function addPasswordToggle() {
+			const apiKeyField = $('#api_key');
+			const toggleButton = $('<button type="button" class="button button-small toggle-password">Show</button>');
+			
+			toggleButton.insertAfter(apiKeyField);
+			
+			toggleButton.on('click', function() {
+				const isPassword = apiKeyField.attr('type') === 'password';
+				apiKeyField.attr('type', isPassword ? 'text' : 'password');
+				$(this).text(isPassword ? 'Hide' : 'Show');
+			});
+		}
+
+		addPasswordToggle();
+	});
+
+})(jQuery);

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     },
     "autoload": {
         "psr-4": {
-            "WPSmartSlug\\": "includes/"
+            "WPSmartSlug\\": "includes/",
+            "WPSmartSlug\\Admin\\": "admin/"
         }
     },
     "autoload-dev": {

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -58,8 +58,10 @@ class Plugin {
 	 * Load admin functionality.
 	 */
 	private function load_admin() {
-		// Admin menu and settings will be initialized here.
-		// This will be implemented in the admin implementation issue.
+		// Initialize admin manager.
+		if ( class_exists( 'WPSmartSlug\Admin\AdminManager' ) ) {
+			\WPSmartSlug\Admin\AdminManager::get_instance();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## 概要
WordPressの管理画面に設定ページを追加し、翻訳サービスの設定ができるようにしました。

## 実装内容

### AdminManager クラス
- シングルトンパターンで設定管理
- WordPress Settings APIを使用した適切な設定処理
- セキュリティ対策（nonce検証、権限チェック）

### 設定ページ機能
- 翻訳サービス選択（ドロップダウン）
- APIキー入力（パスワードフィールド、表示/非表示切り替え）
- APIホスト設定（LibreTranslate用）
- 機能の有効/無効切り替え（投稿、固定ページ、メディア）

### JavaScript機能
- サービス選択に応じた動的フィールド表示
- フォームバリデーション（必須項目チェック）
- APIキーの表示/非表示切り替え
- リアルタイムヘルプテキスト更新

### UI/UX
- WordPress標準デザインに準拠
- レスポンシブデザイン
- 詳細なヘルプテキストとサービス説明
- プロフェッショナルなスタイリング

### その他
- プラグイン一覧にSettings リンクを追加
- Composerオートローダーに管理画面クラスを追加
- コアプラグインクラスから管理機能を初期化

Closes #5