### PR TITLE
Fix #7: WordPressフックの実装

### DIFF
--- a/admin/BatchAdmin.php
+++ b/admin/BatchAdmin.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Batch processing admin interface.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Admin;
+
+use WPSmartSlug\Hooks\BatchProcessor;
+use WPSmartSlug\Hooks\HookManager;
+
+/**
+ * Manages batch processing admin interface.
+ */
+class BatchAdmin {
+
+	/**
+	 * Instance of this class.
+	 *
+	 * @var BatchAdmin|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return BatchAdmin
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Initialize batch admin functionality.
+	 */
+	private function init() {
+		add_action( 'admin_menu', [ $this, 'add_batch_page' ] );
+		add_action( 'wp_ajax_wp_smart_slug_batch_process', [ $this, 'handle_batch_process' ] );
+		add_action( 'wp_ajax_wp_smart_slug_get_stats', [ $this, 'handle_get_stats' ] );
+		add_action( 'wp_ajax_wp_smart_slug_reset_status', [ $this, 'handle_reset_status' ] );
+	}
+
+	/**
+	 * Add batch processing page to admin menu.
+	 */
+	public function add_batch_page() {
+		add_submenu_page(
+			'options-general.php',
+			__( 'WP Smart Slug - Batch Process', 'wp-smart-slug' ),
+			__( 'WP Smart Slug Batch', 'wp-smart-slug' ),
+			'manage_options',
+			'wp-smart-slug-batch',
+			[ $this, 'render_batch_page' ]
+		);
+	}
+
+	/**
+	 * Render batch processing page.
+	 */
+	public function render_batch_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-smart-slug' ) );
+		}
+
+		$hook_manager   = HookManager::get_instance();
+		$slug_generator = $hook_manager->get_slug_generator();
+		$batch_processor = new BatchProcessor( $slug_generator );
+		$stats = $batch_processor->get_processing_stats();
+
+		include WP_SMART_SLUG_PLUGIN_DIR . 'admin/views/batch-page.php';
+	}
+
+	/**
+	 * Handle AJAX batch processing request.
+	 */
+	public function handle_batch_process() {
+		check_ajax_referer( 'wp_smart_slug_batch', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions.', 'wp-smart-slug' ) );
+		}
+
+		$hook_manager    = HookManager::get_instance();
+		$slug_generator  = $hook_manager->get_slug_generator();
+		$batch_processor = new BatchProcessor( $slug_generator );
+
+		$batch_size = intval( $_POST['batch_size'] ?? 10 );
+		$post_type  = sanitize_text_field( $_POST['post_type'] ?? 'all' );
+
+		$args = [];
+		if ( 'all' !== $post_type ) {
+			$args['post_type'] = [ $post_type ];
+		}
+
+		$results = $batch_processor->process_posts( $args, $batch_size );
+		$stats   = $batch_processor->get_processing_stats();
+
+		wp_send_json_success(
+			[
+				'results' => $results,
+				'stats'   => $stats,
+			]
+		);
+	}
+
+	/**
+	 * Handle AJAX get statistics request.
+	 */
+	public function handle_get_stats() {
+		check_ajax_referer( 'wp_smart_slug_batch', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions.', 'wp-smart-slug' ) );
+		}
+
+		$hook_manager    = HookManager::get_instance();
+		$slug_generator  = $hook_manager->get_slug_generator();
+		$batch_processor = new BatchProcessor( $slug_generator );
+		$stats           = $batch_processor->get_processing_stats();
+
+		wp_send_json_success( $stats );
+	}
+
+	/**
+	 * Handle AJAX reset status request.
+	 */
+	public function handle_reset_status() {
+		check_ajax_referer( 'wp_smart_slug_batch', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions.', 'wp-smart-slug' ) );
+		}
+
+		$hook_manager    = HookManager::get_instance();
+		$slug_generator  = $hook_manager->get_slug_generator();
+		$batch_processor = new BatchProcessor( $slug_generator );
+		$reset_count     = $batch_processor->reset_processing_status();
+
+		wp_send_json_success(
+			[
+				'reset_count' => $reset_count,
+				'message'     => sprintf(
+					/* translators: %d: number of posts reset */
+					_n(
+						'Reset %d post.',
+						'Reset %d posts.',
+						$reset_count,
+						'wp-smart-slug'
+					),
+					$reset_count
+				),
+			]
+		);
+	}
+}

--- a/admin/views/batch-page.php
+++ b/admin/views/batch-page.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Batch processing page template.
+ *
+ * @package WPSmartSlug
+ */
+
+// Prevent direct access.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+
+<div class="wrap">
+	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+
+	<div class="wp-smart-slug-batch">
+		<div class="batch-stats">
+			<h2><?php esc_html_e( 'Processing Statistics', 'wp-smart-slug' ); ?></h2>
+			<table class="widefat fixed">
+				<tbody>
+					<tr>
+						<td><strong><?php esc_html_e( 'Total Posts', 'wp-smart-slug' ); ?></strong></td>
+						<td id="stat-total"><?php echo esc_html( number_format( $stats['total'] ) ); ?></td>
+					</tr>
+					<tr>
+						<td><strong><?php esc_html_e( 'Processed', 'wp-smart-slug' ); ?></strong></td>
+						<td id="stat-processed"><?php echo esc_html( number_format( $stats['processed'] ) ); ?></td>
+					</tr>
+					<tr>
+						<td><strong><?php esc_html_e( 'Remaining', 'wp-smart-slug' ); ?></strong></td>
+						<td id="stat-remaining"><?php echo esc_html( number_format( $stats['remaining'] ) ); ?></td>
+					</tr>
+					<tr>
+						<td><strong><?php esc_html_e( 'Progress', 'wp-smart-slug' ); ?></strong></td>
+						<td>
+							<div class="progress-bar">
+								<div class="progress-fill" id="progress-fill" style="width: <?php echo esc_attr( $stats['percentage'] ); ?>%"></div>
+							</div>
+							<span id="progress-text"><?php echo esc_html( $stats['percentage'] ); ?>%</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<div class="batch-controls">
+			<h2><?php esc_html_e( 'Batch Processing', 'wp-smart-slug' ); ?></h2>
+			<p><?php esc_html_e( 'Process existing posts and pages to translate their slugs to English.', 'wp-smart-slug' ); ?></p>
+
+			<form id="batch-form">
+				<?php wp_nonce_field( 'wp_smart_slug_batch', 'wp_smart_slug_batch_nonce' ); ?>
+				
+				<table class="form-table">
+					<tr>
+						<th scope="row">
+							<label for="post-type"><?php esc_html_e( 'Content Type', 'wp-smart-slug' ); ?></label>
+						</th>
+						<td>
+							<select id="post-type" name="post_type">
+								<option value="all"><?php esc_html_e( 'All (Posts, Pages, Media)', 'wp-smart-slug' ); ?></option>
+								<option value="post"><?php esc_html_e( 'Posts Only', 'wp-smart-slug' ); ?></option>
+								<option value="page"><?php esc_html_e( 'Pages Only', 'wp-smart-slug' ); ?></option>
+								<option value="attachment"><?php esc_html_e( 'Media Only', 'wp-smart-slug' ); ?></option>
+							</select>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">
+							<label for="batch-size"><?php esc_html_e( 'Batch Size', 'wp-smart-slug' ); ?></label>
+						</th>
+						<td>
+							<input type="number" id="batch-size" name="batch_size" value="10" min="1" max="100" class="small-text" />
+							<p class="description"><?php esc_html_e( 'Number of posts to process in each batch (1-100).', 'wp-smart-slug' ); ?></p>
+						</td>
+					</tr>
+				</table>
+
+				<p class="submit">
+					<button type="button" id="start-batch" class="button button-primary">
+						<?php esc_html_e( 'Start Processing', 'wp-smart-slug' ); ?>
+					</button>
+					<button type="button" id="stop-batch" class="button" style="display: none;">
+						<?php esc_html_e( 'Stop Processing', 'wp-smart-slug' ); ?>
+					</button>
+					<button type="button" id="refresh-stats" class="button">
+						<?php esc_html_e( 'Refresh Statistics', 'wp-smart-slug' ); ?>
+					</button>
+					<button type="button" id="reset-status" class="button">
+						<?php esc_html_e( 'Reset Processing Status', 'wp-smart-slug' ); ?>
+					</button>
+				</p>
+			</form>
+		</div>
+
+		<div class="batch-log">
+			<h2><?php esc_html_e( 'Processing Log', 'wp-smart-slug' ); ?></h2>
+			<div id="log-container">
+				<p><?php esc_html_e( 'Click "Start Processing" to begin.', 'wp-smart-slug' ); ?></p>
+			</div>
+		</div>
+	</div>
+</div>
+
+<style>
+.wp-smart-slug-batch {
+	max-width: 800px;
+}
+
+.batch-stats,
+.batch-controls,
+.batch-log {
+	background: #fff;
+	border: 1px solid #ccd0d4;
+	padding: 20px;
+	margin-bottom: 20px;
+}
+
+.progress-bar {
+	width: 200px;
+	height: 20px;
+	background: #f0f0f0;
+	border: 1px solid #ccc;
+	border-radius: 10px;
+	overflow: hidden;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: 10px;
+}
+
+.progress-fill {
+	height: 100%;
+	background: linear-gradient(to right, #00a32a, #4caf50);
+	transition: width 0.3s ease;
+}
+
+#log-container {
+	background: #f9f9f9;
+	border: 1px solid #ddd;
+	padding: 10px;
+	height: 200px;
+	overflow-y: auto;
+	font-family: monospace;
+	font-size: 12px;
+}
+
+.log-entry {
+	margin-bottom: 5px;
+	padding: 2px 5px;
+}
+
+.log-entry.success {
+	color: #00a32a;
+}
+
+.log-entry.error {
+	color: #dc3232;
+}
+
+.log-entry.info {
+	color: #666;
+}
+
+.processing .button {
+	opacity: 0.6;
+	pointer-events: none;
+}
+
+.processing #stop-batch {
+	opacity: 1;
+	pointer-events: auto;
+}
+</style>
+
+<script>
+jQuery(document).ready(function($) {
+	let processing = false;
+	let processingInterval = null;
+
+	const logContainer = $('#log-container');
+	const startButton = $('#start-batch');
+	const stopButton = $('#stop-batch');
+
+	function addLogEntry(message, type = 'info') {
+		const timestamp = new Date().toLocaleTimeString();
+		const entry = $('<div class="log-entry ' + type + '">[' + timestamp + '] ' + message + '</div>');
+		logContainer.append(entry);
+		logContainer.scrollTop(logContainer[0].scrollHeight);
+	}
+
+	function updateStats(stats) {
+		$('#stat-total').text(stats.total.toLocaleString());
+		$('#stat-processed').text(stats.processed.toLocaleString());
+		$('#stat-remaining').text(stats.remaining.toLocaleString());
+		$('#progress-fill').css('width', stats.percentage + '%');
+		$('#progress-text').text(stats.percentage + '%');
+	}
+
+	function processBatch() {
+		if (!processing) return;
+
+		const formData = {
+			action: 'wp_smart_slug_batch_process',
+			nonce: $('#wp_smart_slug_batch_nonce').val(),
+			post_type: $('#post-type').val(),
+			batch_size: $('#batch-size').val()
+		};
+
+		$.post(ajaxurl, formData)
+			.done(function(response) {
+				if (response.success) {
+					const results = response.data.results;
+					const stats = response.data.stats;
+
+					addLogEntry('Processed ' + results.processed + ' items, updated ' + results.updated + ' slugs', 'success');
+					
+					if (results.errors.length > 0) {
+						results.errors.forEach(function(error) {
+							addLogEntry('Error: ' + error, 'error');
+						});
+					}
+
+					updateStats(stats);
+
+					if (stats.remaining === 0) {
+						stopProcessing();
+						addLogEntry('Processing complete!', 'success');
+					}
+				} else {
+					addLogEntry('Error: ' + response.data, 'error');
+					stopProcessing();
+				}
+			})
+			.fail(function() {
+				addLogEntry('AJAX request failed', 'error');
+				stopProcessing();
+			});
+	}
+
+	function startProcessing() {
+		processing = true;
+		$('.wp-smart-slug-batch').addClass('processing');
+		startButton.hide();
+		stopButton.show();
+		
+		addLogEntry('Starting batch processing...', 'info');
+		logContainer.empty().append('<div class="log-entry info">[' + new Date().toLocaleTimeString() + '] Starting batch processing...</div>');
+		
+		processingInterval = setInterval(processBatch, 2000); // Process every 2 seconds
+		processBatch(); // Start immediately
+	}
+
+	function stopProcessing() {
+		processing = false;
+		$('.wp-smart-slug-batch').removeClass('processing');
+		startButton.show();
+		stopButton.hide();
+		
+		if (processingInterval) {
+			clearInterval(processingInterval);
+			processingInterval = null;
+		}
+		
+		addLogEntry('Processing stopped', 'info');
+	}
+
+	startButton.on('click', startProcessing);
+	stopButton.on('click', stopProcessing);
+
+	$('#refresh-stats').on('click', function() {
+		$.post(ajaxurl, {
+			action: 'wp_smart_slug_get_stats',
+			nonce: $('#wp_smart_slug_batch_nonce').val()
+		}).done(function(response) {
+			if (response.success) {
+				updateStats(response.data);
+				addLogEntry('Statistics refreshed', 'info');
+			}
+		});
+	});
+
+	$('#reset-status').on('click', function() {
+		if (confirm('Are you sure you want to reset the processing status? This will allow all posts to be processed again.')) {
+			$.post(ajaxurl, {
+				action: 'wp_smart_slug_reset_status',
+				nonce: $('#wp_smart_slug_batch_nonce').val()
+			}).done(function(response) {
+				if (response.success) {
+					addLogEntry(response.data.message, 'success');
+					$('#refresh-stats').click(); // Refresh stats
+				}
+			});
+		}
+	});
+});
+</script>

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -62,14 +62,21 @@ class Plugin {
 		if ( class_exists( 'WPSmartSlug\Admin\AdminManager' ) ) {
 			\WPSmartSlug\Admin\AdminManager::get_instance();
 		}
+
+		// Initialize batch admin.
+		if ( class_exists( 'WPSmartSlug\Admin\BatchAdmin' ) ) {
+			\WPSmartSlug\Admin\BatchAdmin::get_instance();
+		}
 	}
 
 	/**
 	 * Load WordPress hooks for slug translation.
 	 */
 	private function load_hooks() {
-		// Hooks for post/page slug translation will be implemented here.
-		// This will be implemented in the WordPress hooks implementation issue.
+		// Initialize hook manager.
+		if ( class_exists( 'WPSmartSlug\Hooks\HookManager' ) ) {
+			\WPSmartSlug\Hooks\HookManager::get_instance();
+		}
 	}
 
 	/**

--- a/includes/Hooks/BatchProcessor.php
+++ b/includes/Hooks/BatchProcessor.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Batch processor for existing content.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Hooks;
+
+use WPSmartSlug\Translation\SlugGenerator;
+
+/**
+ * Handles batch processing of existing content.
+ */
+class BatchProcessor {
+
+	/**
+	 * Slug generator instance.
+	 *
+	 * @var SlugGenerator
+	 */
+	private $slug_generator;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SlugGenerator $slug_generator Slug generator instance.
+	 */
+	public function __construct( SlugGenerator $slug_generator ) {
+		$this->slug_generator = $slug_generator;
+	}
+
+	/**
+	 * Process posts in batches.
+	 *
+	 * @param array $args Query arguments.
+	 * @param int   $batch_size Number of posts to process at once.
+	 *
+	 * @return array Processing results.
+	 */
+	public function process_posts( array $args = [], int $batch_size = 20 ): array {
+		$default_args = [
+			'post_type'      => [ 'post', 'page' ],
+			'post_status'    => 'any',
+			'posts_per_page' => $batch_size,
+			'meta_query'     => [
+				[
+					'key'     => '_wp_smart_slug_processed',
+					'compare' => 'NOT EXISTS',
+				],
+			],
+		];
+
+		$query_args = wp_parse_args( $args, $default_args );
+		$posts      = get_posts( $query_args );
+		$results    = [
+			'processed' => 0,
+			'updated'   => 0,
+			'errors'    => [],
+		];
+
+		foreach ( $posts as $post ) {
+			$result = $this->process_single_post( $post );
+			$results['processed']++;
+
+			if ( $result['updated'] ) {
+				$results['updated']++;
+			}
+
+			if ( ! empty( $result['error'] ) ) {
+				$results['errors'][] = $result['error'];
+			}
+
+			// Mark as processed.
+			update_post_meta( $post->ID, '_wp_smart_slug_processed', time() );
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Process a single post.
+	 *
+	 * @param \WP_Post $post Post object.
+	 *
+	 * @return array Processing result.
+	 */
+	private function process_single_post( \WP_Post $post ): array {
+		$result = [
+			'updated' => false,
+			'error'   => '',
+		];
+
+		// Check if post title needs translation.
+		if ( ! $this->needs_translation( $post->post_title ) ) {
+			return $result;
+		}
+
+		// Check if slug already looks translated.
+		if ( ! $this->needs_translation( $post->post_name ) ) {
+			return $result;
+		}
+
+		try {
+			// Generate translated slug.
+			$translated_slug = $this->slug_generator->generate_slug( $post->post_title );
+
+			if ( empty( $translated_slug ) ) {
+				$result['error'] = sprintf(
+					/* translators: %d: post ID */
+					__( 'Failed to generate slug for post ID %d', 'wp-smart-slug' ),
+					$post->ID
+				);
+				return $result;
+			}
+
+			// Ensure slug is unique.
+			$unique_slug = wp_unique_post_slug(
+				$translated_slug,
+				$post->ID,
+				$post->post_status,
+				$post->post_type,
+				$post->post_parent
+			);
+
+			// Update post slug.
+			$updated = wp_update_post(
+				[
+					'ID'        => $post->ID,
+					'post_name' => $unique_slug,
+				],
+				true
+			);
+
+			if ( is_wp_error( $updated ) ) {
+				$result['error'] = sprintf(
+					/* translators: %1$d: post ID, %2$s: error message */
+					__( 'Failed to update post ID %1$d: %2$s', 'wp-smart-slug' ),
+					$post->ID,
+					$updated->get_error_message()
+				);
+			} else {
+				$result['updated'] = true;
+			}
+		} catch ( Exception $e ) {
+			$result['error'] = sprintf(
+				/* translators: %1$d: post ID, %2$s: error message */
+				__( 'Exception processing post ID %1$d: %2$s', 'wp-smart-slug' ),
+				$post->ID,
+				$e->getMessage()
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Process media attachments in batches.
+	 *
+	 * @param int $batch_size Number of attachments to process at once.
+	 *
+	 * @return array Processing results.
+	 */
+	public function process_media( int $batch_size = 20 ): array {
+		$args = [
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+			'posts_per_page' => $batch_size,
+			'meta_query'     => [
+				[
+					'key'     => '_wp_smart_slug_processed',
+					'compare' => 'NOT EXISTS',
+				],
+			],
+		];
+
+		return $this->process_posts( $args, $batch_size );
+	}
+
+	/**
+	 * Reset processing status for all content.
+	 *
+	 * @return int Number of posts reset.
+	 */
+	public function reset_processing_status(): int {
+		global $wpdb;
+
+		$result = $wpdb->delete(
+			$wpdb->postmeta,
+			[ 'meta_key' => '_wp_smart_slug_processed' ]
+		);
+
+		return $result ?: 0;
+	}
+
+	/**
+	 * Get processing statistics.
+	 *
+	 * @return array Statistics array.
+	 */
+	public function get_processing_stats(): array {
+		global $wpdb;
+
+		// Count total posts that need processing.
+		$total_posts = $wpdb->get_var(
+			"SELECT COUNT(*) FROM {$wpdb->posts} 
+			WHERE post_type IN ('post', 'page', 'attachment') 
+			AND post_status IN ('publish', 'inherit', 'private', 'draft')"
+		);
+
+		// Count processed posts.
+		$processed_posts = $wpdb->get_var(
+			"SELECT COUNT(*) FROM {$wpdb->postmeta} 
+			WHERE meta_key = '_wp_smart_slug_processed'"
+		);
+
+		return [
+			'total'      => (int) $total_posts,
+			'processed'  => (int) $processed_posts,
+			'remaining'  => (int) $total_posts - (int) $processed_posts,
+			'percentage' => $total_posts > 0 ? round( ( $processed_posts / $total_posts ) * 100, 2 ) : 0,
+		];
+	}
+
+	/**
+	 * Check if text needs translation.
+	 *
+	 * @param string $text Text to check.
+	 *
+	 * @return bool True if translation is needed.
+	 */
+	private function needs_translation( string $text ): bool {
+		return ! preg_match( '/^[\x20-\x7E]*$/', $text );
+	}
+}

--- a/includes/Hooks/HookManager.php
+++ b/includes/Hooks/HookManager.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Hook manager class.
+ *
+ * @package WPSmartSlug
+ */
+
+namespace WPSmartSlug\Hooks;
+
+use WPSmartSlug\Translation\TranslationServiceFactory;
+use WPSmartSlug\Translation\SlugGenerator;
+
+/**
+ * Manages WordPress hooks for slug translation.
+ */
+class HookManager {
+
+	/**
+	 * Instance of this class.
+	 *
+	 * @var HookManager|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Slug generator instance.
+	 *
+	 * @var SlugGenerator|null
+	 */
+	private $slug_generator;
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return HookManager
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Initialize hooks.
+	 */
+	private function init() {
+		// Initialize slug generator.
+		$this->setup_slug_generator();
+
+		// Hook for post/page slug translation.
+		add_filter( 'wp_insert_post_data', [ $this, 'translate_post_slug' ], 10, 2 );
+
+		// Hook for media filename translation.
+		add_filter( 'sanitize_file_name', [ $this, 'translate_media_filename' ], 10, 1 );
+
+		// Hook for attachment post name (slug).
+		add_filter( 'wp_insert_attachment_data', [ $this, 'translate_attachment_slug' ], 10, 2 );
+	}
+
+	/**
+	 * Setup slug generator with current translation service.
+	 */
+	private function setup_slug_generator() {
+		$service_name = get_option( 'wp_smart_slug_translation_service', 'mymemory' );
+		
+		$config = [
+			'api_key'  => get_option( 'wp_smart_slug_api_key', '' ),
+			'api_host' => get_option( 'wp_smart_slug_api_host', '' ),
+		];
+
+		$service = TranslationServiceFactory::create( $service_name, $config );
+		$this->slug_generator = new SlugGenerator( $service );
+	}
+
+	/**
+	 * Translate post/page slug.
+	 *
+	 * @param array $data    An array of slashed post data.
+	 * @param array $postarr An array of sanitized, but otherwise unmodified post data.
+	 *
+	 * @return array Modified post data.
+	 */
+	public function translate_post_slug( $data, $postarr ) {
+		// Skip if this is an update and slug is already set.
+		if ( ! empty( $postarr['ID'] ) && ! empty( $data['post_name'] ) ) {
+			return $data;
+		}
+
+		// Check if feature is enabled for this post type.
+		if ( ! $this->is_feature_enabled_for_post_type( $data['post_type'] ) ) {
+			return $data;
+		}
+
+		// Skip if post title is empty.
+		if ( empty( $data['post_title'] ) ) {
+			return $data;
+		}
+
+		// Skip if slug is already set to something other than default.
+		if ( ! empty( $data['post_name'] ) && $data['post_name'] !== sanitize_title( $data['post_title'] ) ) {
+			return $data;
+		}
+
+		// Check if title needs translation.
+		if ( ! $this->needs_translation( $data['post_title'] ) ) {
+			return $data;
+		}
+
+		// Generate translated slug.
+		$translated_slug = $this->slug_generator->generate_slug( $data['post_title'] );
+
+		if ( ! empty( $translated_slug ) ) {
+			$data['post_name'] = $translated_slug;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Translate media filename.
+	 *
+	 * @param string $filename The sanitized filename.
+	 *
+	 * @return string Modified filename.
+	 */
+	public function translate_media_filename( $filename ) {
+		// Skip if media translation is disabled.
+		if ( ! get_option( 'wp_smart_slug_enable_media', true ) ) {
+			return $filename;
+		}
+
+		// Skip if filename doesn't need translation.
+		if ( ! $this->needs_translation( $filename ) ) {
+			return $filename;
+		}
+
+		// Generate translated filename.
+		$translated_filename = $this->slug_generator->generate_media_slug( $filename );
+
+		return ! empty( $translated_filename ) ? $translated_filename : $filename;
+	}
+
+	/**
+	 * Translate attachment slug.
+	 *
+	 * @param array $data    An array of slashed attachment data.
+	 * @param array $postarr An array of sanitized, but otherwise unmodified post data.
+	 *
+	 * @return array Modified attachment data.
+	 */
+	public function translate_attachment_slug( $data, $postarr ) {
+		// Skip if media translation is disabled.
+		if ( ! get_option( 'wp_smart_slug_enable_media', true ) ) {
+			return $data;
+		}
+
+		// Skip if this is an update and slug is already set.
+		if ( ! empty( $postarr['ID'] ) && ! empty( $data['post_name'] ) ) {
+			return $data;
+		}
+
+		// Skip if post title is empty.
+		if ( empty( $data['post_title'] ) ) {
+			return $data;
+		}
+
+		// Check if title needs translation.
+		if ( ! $this->needs_translation( $data['post_title'] ) ) {
+			return $data;
+		}
+
+		// Generate translated slug for attachment.
+		$translated_slug = $this->slug_generator->generate_slug( $data['post_title'] );
+
+		if ( ! empty( $translated_slug ) ) {
+			$data['post_name'] = $translated_slug;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Check if feature is enabled for post type.
+	 *
+	 * @param string $post_type Post type to check.
+	 *
+	 * @return bool True if enabled, false otherwise.
+	 */
+	private function is_feature_enabled_for_post_type( $post_type ) {
+		switch ( $post_type ) {
+			case 'post':
+				return get_option( 'wp_smart_slug_enable_posts', true );
+			case 'page':
+				return get_option( 'wp_smart_slug_enable_pages', true );
+			case 'attachment':
+				return get_option( 'wp_smart_slug_enable_media', true );
+			default:
+				// Allow third-party post types via filter.
+				return apply_filters( 'wp_smart_slug_enable_for_post_type', false, $post_type );
+		}
+	}
+
+	/**
+	 * Check if text needs translation.
+	 *
+	 * @param string $text Text to check.
+	 *
+	 * @return bool True if translation is needed.
+	 */
+	private function needs_translation( $text ) {
+		// Check if text contains non-ASCII characters.
+		return ! preg_match( '/^[\x20-\x7E]*$/', $text );
+	}
+
+	/**
+	 * Get slug generator instance.
+	 *
+	 * @return SlugGenerator|null
+	 */
+	public function get_slug_generator() {
+		return $this->slug_generator;
+	}
+
+	/**
+	 * Force refresh of translation service configuration.
+	 */
+	public function refresh_translation_service() {
+		$this->setup_slug_generator();
+	}
+}


### PR DESCRIPTION
## 概要
投稿、固定ページ、メディアのslug/ファイル名を自動翻訳するためのWordPressフックを実装しました。

## 実装内容

### HookManager クラス
- 新規投稿・ページ作成時の自動slug翻訳
- メディアアップロード時のファイル名翻訳
- 添付ファイルのpost_name翻訳
- 投稿タイプごとの有効/無効設定対応
- 非ASCII文字の検出による翻訳対象の判定

### BatchProcessor クラス
- 既存コンテンツの一括翻訳処理
- バッチサイズの設定による性能調整
- 処理状況追跡（重複処理防止）
- 統計情報と進捗追跡
- エラーハンドリングとログ出力

### BatchAdmin クラス
- バッチ処理用の管理画面
- リアルタイム進捗表示（プログレスバー）
- AJAX によるスタート/ストップ制御
- タイムスタンプ付き処理ログ
- 統計ダッシュボード（合計/処理済み/残り）
- 処理状態リセット機能

## WordPressフック統合
- `wp_insert_post_data`: 新規投稿・ページ
- `sanitize_file_name`: メディアアップロード
- `wp_insert_attachment_data`: 添付ファイル
- `wp_unique_post_slug`: 重複slug防止
- 設定による機能切り替え対応

## 特徴
- 非ASCII文字検出による効率的な翻訳対象選別
- 翻訳失敗時の適切なフォールバック
- 翻訳済みコンテンツの再処理防止
- カスタム投稿タイプのフィルター対応
- パフォーマンス最適化されたバッチ処理
- メモリ効率的なチャンク処理

Closes #7